### PR TITLE
Implement infrastructure for server controllers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,8 @@
 
 #### API changes
 
-##### `pub mod euclidon`
-* Created module.
+##### Crate `euclidon`
+* Created crate.
 * Added `enum Error`
     * Defined in `mod euclidon::error`.
     * The generic error type used throughout `euclidon` crate.
@@ -16,6 +16,10 @@
     * Wraps over various error types thrown by other modules or crates, and has `trait From<...>` implementations for all of them.
 * Added alias `App = struct app::App`.
 * Added alias `AppState = struct app::AppState`.
+* Added `pub fn build_router(app: Arc<App>) -> axum::Router`
+    * Defined in `mod euclidon::router`.
+    * Constructs an axum router with the provided `app` instance as its state.
+    * State can be extracted via the custom `AppState` extractor.
 
 ##### `pub mod euclidon::app`
 * Created module.

--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,11 @@
     * `pub fn load() -> Result<Self, Error>`
         * Equivalent to `Config::builder().build()`.
 
+##### `pub mod euclidon::controllers`
+* Created module.
+* Contains all method handlers for different routes. Each route is mapped to a corresponding submodule, and each submodule contains controllers for the same route with different methods such as `GET` or `POST`.
+* Route to controller mapping is as follows:
+    * `/` to `root::get` with `GET`
 
 #### Internal changes
 * Set Rust compilation version at v1.84.0 and edition to 2021.

--- a/changelog.md
+++ b/changelog.md
@@ -5,11 +5,42 @@
 ### v0.1.0
 
 #### API changes
-* Added `enum euclidon::Error`
-    * The generic error type used throughout `euclidon`.
+
+##### `pub mod euclidon`
+* Created module.
+* Added `enum Error`
+    * Defined in `mod euclidon::error`.
+    * The generic error type used throughout `euclidon` crate.
     * Derives implementations for `trait Debug` and `trait thiserror::Error`.
     * Implements `trait axum::response::IntoResponse`, so it can be used in HTTP method handlers.
     * Wraps over various error types thrown by other modules or crates, and has `trait From<...>` implementations for all of them.
+* Added alias `App = struct app::App`.
+* Added alias `AppState = struct app::AppState`.
+
+##### `pub mod euclidon::app`
+* Created module.
+* Added `struct App`
+    * Represents the global data of a server instance.
+    * `pub config: Config`
+        * Contains server configuration.
+    * `pub fn new(config: Config) -> Result<Self, Error>`
+        * Constructs an app with the given configuration.
+        * On failure returns `Err(euclidon::Error)`.
+* Added `struct AppState`
+    * Wrapper for an instance of `Arc<App>`.
+    * Derives `trait Clone` and `trait axum::extract::FromRequestParts` via `struct axum::extact::State`, so it can be used directly as an extractor for axum method handlers rather than `State<Arc<App>>`.
+    * Implements `trait Deref<Target = App>` so it can be seamlessly used as an `App` instance.
+* Added `struct Config`
+    * Contains the server configuration and options.
+    * `pub server_url: String`
+        * The URL of the server.
+        * Default value is loaded from environmental variable `SERVER_URL` that can be changed via the .env file.
+        * Alternatively, set using `.server_url(server_url: String)` function of builder.
+    * `pub fn builder() -> ConfigBuilder`
+        * Returns a builder. The builder type is hidden in the private module `app::detail`.
+    * `pub fn load() -> Result<Self, Error>`
+        * Equivalent to `Config::builder().build()`.
+
 
 #### Internal changes
 * Set Rust compilation version at v1.84.0 and edition to 2021.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,68 @@
+use std::{ops::Deref, sync::Arc};
+
+use axum::extract::{FromRequestParts, State};
+
+use crate::Error;
+
+use self::detail::ConfigBuilder;
+
+pub struct App {
+    pub config: Config,
+}
+
+impl App {
+    pub fn new(config: Config) -> Result<Self, Error> {
+        Ok(Self { config })
+    }
+}
+
+#[derive(Clone, FromRequestParts)]
+#[from_request(via(State))]
+pub struct AppState(pub Arc<App>);
+
+impl Deref for AppState {
+    type Target = App;
+
+    fn deref(&self) -> &App {
+        &self.0
+    }
+}
+
+pub struct Config {
+    pub server_url: String,
+}
+
+impl Config {
+    pub fn load() -> Result<Self, Error> {
+        Self::builder().build()
+    }
+
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::default()
+    }
+}
+
+#[doc(hidden)]
+mod detail {
+    use crate::{app::Config, Error};
+
+    #[derive(Default)]
+    pub struct ConfigBuilder {
+        server_url: Option<String>,
+    }
+
+    impl ConfigBuilder {
+        pub fn build(self) -> Result<Config, Error> {
+            Ok(Config {
+                server_url: self
+                    .server_url
+                    .map_or_else(|| std::env::var("SERVER_URL"), Ok)?,
+            })
+        }
+
+        pub fn server_url(mut self, server_url: String) -> Self {
+            self.server_url = Some(server_url);
+            self
+        }
+    }
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,0 +1,1 @@
+pub mod root;

--- a/src/controllers/root.rs
+++ b/src/controllers/root.rs
@@ -1,0 +1,11 @@
+use axum::{
+    debug_handler,
+    response::{IntoResponse, Response},
+};
+
+use crate::Error;
+
+#[debug_handler(state = AppState)]
+pub async fn get() -> Result<Response, Error> {
+    Ok("Hello, world!".into_response())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod app;
 mod error;
+mod router;
 
 pub use self::{
     app::{App, AppState},
     error::Error,
+    router::build_router,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod controllers;
 mod error;
 mod router;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod app;
 mod error;
 
-pub use self::error::Error;
+pub use self::{
+    app::{App, AppState},
+    error::Error,
+};

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use axum::{debug_handler, response::IntoResponse, routing::get, Router};
+
+use crate::{App, AppState};
+
+pub fn build_router(app: Arc<App>) -> Router {
+    Router::new()
+        .route("/", get(root))
+        .with_state(AppState(app))
+}
+
+#[debug_handler(state = AppState)]
+async fn root(AppState(_): AppState) -> impl IntoResponse {
+    "Hello, world!"
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,16 +1,11 @@
 use std::sync::Arc;
 
-use axum::{debug_handler, response::IntoResponse, routing::get, Router};
+use axum::{routing::get, Router};
 
-use crate::{App, AppState};
+use crate::{controllers::root, App, AppState};
 
 pub fn build_router(app: Arc<App>) -> Router {
     Router::new()
-        .route("/", get(root))
+        .route("/", get(root::get))
         .with_state(AppState(app))
-}
-
-#[debug_handler(state = AppState)]
-async fn root(AppState(_): AppState) -> impl IntoResponse {
-    "Hello, world!"
 }


### PR DESCRIPTION
This PR implements the basic infrastructure for proper server routing, and passing these routes to specified controllers that accept server-global information as well.