### PR TITLE
Added missing builder function for `database_url` in `struct app::Config`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,10 @@
         * The URL of the server.
         * Default value is loaded from environmental variable `SERVER_URL` provided through the .env file.
         * Alternatively, set using `.server_url(server_url: String)` function from the builder.
+    * Added member `database_url: String`.
+        * The URL of the database.
+        * Default value is loaded from environmental variable `DATABASE_URL` provided through the .env file.
+        * Alternatively, set using `.database_url(database_url: String)` function from the builder.
     * Added member `assets_dir: PathBuf`.
         * Path of the main assets directory.
         * Default value is `assets/euclidon`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -91,6 +91,11 @@ mod detail {
             self
         }
 
+        pub fn database_url(mut self, database_url: String) -> Self {
+            self.database_url = Some(database_url);
+            self
+        }
+
         pub fn assets_dir(mut self, assets_dir: PathBuf) -> Self {
             self.assets_dir = Some(assets_dir);
             self


### PR DESCRIPTION
As an oversight, the builder function and the changelog description for `database_url` was missing for `struct app::Config`. This single-commit PR fixes this oversight.