### PR TITLE
Implement infrastructure for background tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ dotenvy = "0.15.7"
 tokio = { version = "1.43.0", features = [
     "rt-multi-thread",
     "macros",
+    "time",
     "net",
     "fs",
 ] }

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,9 @@
     * Defined in `mod euclidon::router`.
     * Constructs an axum router with the provided `app` instance as its state.
     * State can be extracted via the custom `AppState` extractor.
+* Added function `fn spawn_tasks(app: Arc<App>) -> Vec<impl JoinHandle<()>>`.
+    * Defined in `mod euclidon::tasks`.
+    * Spawns the various background tasks required by Euclidon.
 
 ##### `mod euclidon::app`
 * Created module.

--- a/changelog.md
+++ b/changelog.md
@@ -148,7 +148,7 @@
 #### Internal changes
 * Set Rust compilation version at v1.84.0 and edition to 2021.
 * Added the following crates as dependencies:
-    * [`tokio`](https://docs.rs/tokio/1.43.0) v1.43.0 with features: `rt-multi-thread`, `macros`, `net`, `fs`
+    * [`tokio`](https://docs.rs/tokio/1.43.0) v1.43.0 with features: `rt-multi-thread`, `macros`, `time`, `net`, `fs`
     * [`axum`](https://docs.rs/axum/0.8.1) v0.8.1 with features: `macros`, `tokio`, `http1`, `http2`, `multipart`, `query`, `form`
     * [`dotenvy`](https://docs.rs/dotenvy/0.15.7) v0.15.7
     * [`thiserror`](https://docs.rs/thiserror/2.0.11) v2.0.11

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,11 @@ pub mod db;
 mod error;
 pub mod render;
 mod router;
+mod tasks;
 
 pub use self::{
     app::{App, AppState},
     error::Error,
     router::build_router,
+    tasks::spawn_tasks,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,13 @@ async fn main() -> Result<(), Error> {
 
     let app = Arc::new(App::new(Config::load()?)?);
     let router = euclidon::build_router(app.clone());
+    _ = euclidon::spawn_tasks(app.clone());
 
     let server_url = &app.config.server_url;
     let listener = TcpListener::bind(server_url).await?;
 
     println!("> server listening on: {server_url}");
-    Ok(axum::serve(listener, router).await?)
+    axum::serve(listener, router).await?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,5 @@ async fn main() -> Result<(), Error> {
     let listener = TcpListener::bind(server_url).await?;
 
     println!("> server listening on: {server_url}");
-    axum::serve(listener, router).await?;
-
-    Ok(())
+    Ok(axum::serve(listener, router).await?)
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,0 +1,9 @@
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+
+use crate::App;
+
+pub fn spawn_tasks(_: Arc<App>) -> Vec<JoinHandle<()>> {
+    vec![]
+}


### PR DESCRIPTION
This PR allows for background tasks to be spawned. These background tasks can do management work that is required for a server, such as occasional database cleanups. This was required as a part of PR # and so was implemented first.